### PR TITLE
fix: access-tokensの渡し方を修正

### DIFF
--- a/.github/workflows/auto-update-flake.yaml
+++ b/.github/workflows/auto-update-flake.yaml
@@ -18,12 +18,9 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          extra-conf: |
-            access-tokens = github.com=${{ secrets.PAT_TOKEN }}
 
       - name: Update flake
-        run: nix flake update
+        run: nix flake update --option access-tokens github.com=${{ secrets.PAT_TOKEN }}
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Summary
- `extra-conf`がuntrustedとして無視されるため、`--option`フラグで直接渡すように変更

## このPRに含まれないこと
- `--auto`マージの動作検証（このPRマージ後に再実行）

ref #28