### PR TITLE
fix: SSH deprecation warningを修正

### DIFF
--- a/home/modules/ssh.nix
+++ b/home/modules/ssh.nix
@@ -9,6 +9,7 @@
 {
   programs.ssh = {
     enable = true;
+    enableDefaultConfig = false;
     matchBlocks = {
       "sshgate.u-aizu.ac.jp" = {
         hostname = "sshgate.u-aizu.ac.jp";


### PR DESCRIPTION
## Summary
- `programs.ssh.enableDefaultConfig = false` を設定してdeprecation warningを解消
- デフォルト値はすべてSSH標準と同じため、`matchBlocks."*"`への移行は不要

closes #27