### PR TITLE
fix: rebuild時のbrew bundleエラーと.zprofile衝突を解消 (closes #55)

### DIFF
--- a/systems/darwin/modules/homebrew.nix
+++ b/systems/darwin/modules/homebrew.nix
@@ -3,22 +3,26 @@
 
   GUIアプリ（casks）とCLIツール（brews）をHomebrewで管理する
   rebuild時に自動更新・アップグレード・不要パッケージの削除（zap）を行う
+  Homebrew (/opt/homebrew/bin) をシステム PATH に追加してユーザーシェルから利用可能にする
 */
 { config, pkgs, ... }:
 {
+  environment.systemPath = [ "/opt/homebrew/bin" ];
+
   homebrew = {
     enable = true;
     onActivation = {
       autoUpdate = true;
       upgrade = true;
       cleanup = "zap";
+      # `brew bundle --cleanup`は確認プロンプトをスキップするため`--force`が必須
+      extraFlags = [ "--force" ];
     };
     brews = [
       "swiftlint"
       "xcodegen"
       "fastlane"
       "go"
-      "rbenv"
       "ktlint"
     ];
     casks = [


### PR DESCRIPTION
## Summary

- `homebrew.onActivation.extraFlags = [ "--force" ];` を追加し、`brew bundle install --cleanup` が `--force` を要求するようになった仕様変更に対応
- `environment.systemPath = [ "/opt/homebrew/bin" ];` を追加し、`brew shellenv` の eval に依存せず宣言的に PATH を設定（[shinbunbun/dotfiles](https://github.com/shinbunbun/dotfiles) `systems/darwin/modules/base.nix` の方式を参考）
- `brews` から未使用の `rbenv` を削除（`~/.rbenv/` は2025-01-07以降未更新、fastlaneはbrewのRubyで動作するため不要）

## Test plan

- [x] `sudo darwin-rebuild switch --flake ~/dotfiles#macOS` がエラーなく完走することを確認
  - `brew bundle complete! 14 Brewfile dependencies now installed.`
  - `Activating linkGeneration` 以降のhome-manager処理が正常進行（`.zprofile` 衝突なし）
- [x] brewで管理されているCLI（swiftlint, xcodegen, fastlane, go, ktlint）が新しいシェルから利用可能であること

## Note

- 既存の `~/.config/zsh/.zprofile`（手書きの brew shellenv / rbenv init）は本PR適用前に手動削除済み
- `~/.rbenv/` ディレクトリの掃除は任意（リポジトリ管理外）
- SSH `programs.ssh.matchBlocks` の deprecation 警告は Issue #47 で別PR対応