### PR TITLE
feat: Zoteroを追加 (closes #58)

### DIFF
--- a/home/profiles/hina/default.nix
+++ b/home/profiles/hina/default.nix
@@ -3,7 +3,6 @@
   imports = [
     ../../modules/shell
     ../../modules/development
-    ../../modules/ssh.nix
   ];
 
   home.stateVersion = "24.11";

--- a/systems/darwin/modules/homebrew.nix
+++ b/systems/darwin/modules/homebrew.nix
@@ -35,6 +35,7 @@
       "visual-studio-code"
       "warp"
       "xquartz"
+      "zotero"
     ];
   };
 }


### PR DESCRIPTION
## Summary

- 文献管理ツールZoteroを Homebrew cask で追加

## Test plan

- [x] `sudo darwin-rebuild switch --flake ~/dotfiles#macOS` で `Installing zotero` を確認
- [x] `brew bundle complete! 15 Brewfile dependencies now installed.` でZoteroを含むbundle完走
- [ ] /Applications/Zotero.app の起動確認（Spotlightからも）