### PR TITLE
feat: poppler-utils を追加

### DIFF
--- a/home/profiles/hina/default.nix
+++ b/home/profiles/hina/default.nix
@@ -27,5 +27,8 @@
 
     # Kubernetes
     kind
+
+    # PDF
+    poppler-utils
   ];
 }


### PR DESCRIPTION
## 概要
PDF をコマンドラインで扱うため poppler-utils を nixpkgs 経由で追加。

## 変更内容
- `home/profiles/hina/default.nix` の `home.packages` に `poppler-utils` を追加

## 動作確認
- `rebuild` 成功
- `pdftotext version 25.10.0` 確認済み

## 補足
nixpkgs では `poppler_utils` は `poppler-utils` に改名されていたためハイフン表記で追加。

closes #85