### PR TITLE
feat: GitHub MCP サーバーを追加

### DIFF
--- a/home/modules/development/github.nix
+++ b/home/modules/development/github.nix
@@ -1,10 +1,29 @@
 /*
-  GitHub CLI
+  GitHub CLI / MCP サーバー
 
-  ghコマンドを提供する（issue作成、PR操作等）
-  設定ファイルはnixで管理せず、既存の~/.config/gh/を使用する
+  提供するツール：
+  - gh: GitHub CLI（issue作成、PR操作等）
+  - github-mcp-server: Claude Code から GitHub を直接操作するための MCP サーバー
+
+  設定:
+  - gh の設定ファイルはnixで管理せず、既存の~/.config/gh/を使用する
+  - github-mcp-server は stdio モードで動作し、gh auth token でトークンを動的取得する
+  - MCP の接続設定は ~/.claude/settings.json に手動で追記する（nix 管理外）
+
+  使用方法:
+  - Claude Code 内で /mcp コマンドにより github サーバーの接続状態を確認できる
 */
 { config, pkgs, ... }:
 {
-  home.packages = [ pkgs.gh ];
+  home.packages = [
+    pkgs.gh
+    pkgs.github-mcp-server
+  ];
+
+  programs.zsh.initExtra = ''
+    # github-mcp-server の認証トークンを gh CLI から動的取得
+    if command -v gh &>/dev/null; then
+      export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+    fi
+  '';
 }


### PR DESCRIPTION
## 概要
Claude Code から GitHub を直接操作できるよう GitHub MCP サーバーを導入する。
closes #43

## 変更内容
- `home/modules/development/github.nix` に `github-mcp-server` パッケージを追加
- zsh initExtra で `GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token)` を動的設定
  - 既に `gh` CLI で認証済みのトークンを再利用するためシークレットの埋め込みなし

## 手動設定（nix 管理外）
- `~/.claude/mcp.json` に mcpServers ブロックを追記済み（`settings.json` のスキーマ外のため別ファイル）

## 動作確認
- `github-mcp-server v1.4.0` のインストールを確認
- 次セッションで `/mcp` コマンドにより接続を確認