### PR TITLE
feat: コンパクション対策の引き継ぎ機構を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 result
 .envrc
 .claude/settings.local.json
+.agent/handoff.md

--- a/home/modules/development/claude-code.nix
+++ b/home/modules/development/claude-code.nix
@@ -2,23 +2,36 @@
   Claude Code 設定モジュール
 
   機能:
-    Claude Code（公式 CLI）のステータスラインスクリプトを配置する。
-    ターミナル下部にモデル名・コンテキスト残量%・Git ブランチ・コストを常時表示する。
+    Claude Code のステータスライン・skills を宣言的にデプロイする。
+
+    ステータスライン:
+      ターミナル下部にモデル名・コンテキスト使用量・Git ブランチ・コスト・レート制限を2段表示する。
+
+    Skills:
+      - handoff: /handoff で .agent/handoff.md に作業状態を構造化して書き出す
+        （コンパクションやセッション再開に備えた手動運用の引き継ぎドキュメント）
 
   設定:
-    home.file で ~/.claude/statusline.sh へ宣言的にデプロイする（実行可能属性付き）。
+    home.file で各ファイルを ~/.claude/ 配下に宣言的にデプロイする。
     settings.json は nix 管理しない（Claude 本体が /config 等で書き込むため）。
-    有効化には ~/.claude/settings.json に以下を手動で追記する：
+    ステータスライン有効化には ~/.claude/settings.json に以下を手動で追記する:
       "statusLine": { "type": "command", "command": "~/.claude/statusline.sh" }
+    skill は ~/.claude/skills/ に置くだけで自動認識される（設定追記不要）。
 
   使用方法:
-    rebuild 後、新しいセッションでステータスラインが表示される。
-    echo '<JSON>' | ~/.claude/statusline.sh で単体テスト可能。
+    rebuild 後、コンテキストが圧迫されてきたら /handoff を実行して
+    .agent/handoff.md を作成・更新する。次セッションでそれを読めば作業を継続できる。
 */
 { ... }:
 {
+  # ステータスライン
   home.file.".claude/statusline.sh" = {
     source = ./claude-statusline.sh;
     executable = true;
+  };
+
+  # Skills
+  home.file.".claude/skills/handoff/SKILL.md" = {
+    source = ./claude-skills/handoff/SKILL.md;
   };
 }

--- a/home/modules/development/claude-skills/handoff/SKILL.md
+++ b/home/modules/development/claude-skills/handoff/SKILL.md
@@ -1,0 +1,44 @@
+Write a handoff document to `.agent/handoff.md` that captures the current session state for continuity after context compaction or session restart.
+
+## When to use
+
+- Context window is filling up (>70%) and compaction is approaching
+- Switching to a new session mid-task
+- Before running `/compact` manually
+
+## Output format
+
+Write `.agent/handoff.md` with the following structure (in English to minimize token cost):
+
+```markdown
+# Handoff
+
+Updated: <ISO timestamp>
+
+## Goal
+<What we are trying to accomplish in one sentence>
+
+## Current State
+<Where we are right now — what's done, what's in progress>
+
+## Key Decisions
+- <Decision made and why>
+
+## Discoveries
+- <fact>: <source file:line or URL>
+
+## Next Steps
+1. <Immediate next action>
+2. <Following action>
+
+## Critical Context
+<Any non-obvious constraints, gotchas, or context that would be lost after compaction>
+```
+
+## Rules
+
+- If `.agent/handoff.md` already exists, UPDATE it — do not overwrite from scratch
+- Keep it concise: the goal is token efficiency, not completeness
+- Do NOT include sensitive values (tokens, passwords, keys)
+- Create `.agent/` directory if it does not exist
+- Always write in English

--- a/home/modules/development/git.nix
+++ b/home/modules/development/git.nix
@@ -38,5 +38,11 @@
       init.defaultBranch = "main";
       core.editor = "code --wait";
     };
+
+    # 全プロジェクト共通の無視設定（~/.config/git/ignore に出力される）
+    ignores = [
+      "**/.claude/settings.local.json"
+      ".agent/handoff.md"
+    ];
   };
 }


### PR DESCRIPTION
## 概要
コンテキストのコンパクションやセッション再開に備えて、作業状態を引き継げる handoff 機構を追加する。closes #110

## 実装内容
- `handoff` skill — /handoff で `.agent/handoff.md` に進捗・決定・次のステップを構造化して書き出す（手動運用）
- `.gitignore` に `.agent/handoff.md` を追加（dotfiles リポジトリ用）
- グローバル gitignore（`~/.config/git/ignore`）にも `.agent/handoff.md` を追加

## 管理方針
- skill は home.file で `~/.claude/skills/` に宣言的デプロイ
- 有効化のための settings.json 追記は不要（skill は自動認識される）
- 自動発火の hooks は今回入れず、手動運用（/handoff）で開始

## 動作確認
- rebuild 成功、`~/.claude/skills/handoff/SKILL.md` デプロイ確認
- グローバル gitignore に既存設定を保持しつつ追加を確認