### PR TITLE
feat: safety-gate hook を追加

### DIFF
--- a/home/modules/development/claude-code.nix
+++ b/home/modules/development/claude-code.nix
@@ -12,12 +12,23 @@
         （コンパクションやセッション再開に備えた手動運用の引き継ぎドキュメント）
       - japanese-tech-writing: 日本語の記事・ノート・技術文書を AI っぽくない自然な文章で書くための規範
 
+    Hooks:
+      - safety-gate: 機密ファイル（SSH秘密鍵・credentials.json 等）へのアクセスを
+        ツール実行前にブロックする PreToolUse hook（auto モードの安全網）
+
   設定:
     home.file で各ファイルを ~/.claude/ 配下に宣言的にデプロイする。
     settings.json は nix 管理しない（Claude 本体が /config 等で書き込むため）。
     ステータスライン有効化には ~/.claude/settings.json に以下を手動で追記する:
       "statusLine": { "type": "command", "command": "~/.claude/statusline.sh" }
     skill は ~/.claude/skills/ に置くだけで自動認識される（設定追記不要）。
+    hook の有効化には ~/.claude/settings.json に以下を手動で追記する:
+      "hooks": {
+        "PreToolUse": [
+          { "matcher": "Read|Write|Edit|Bash|Grep",
+            "hooks": [{ "type": "command", "command": "~/.claude/hooks/safety-gate.sh" }] }
+        ]
+      }
 
   使用方法:
     rebuild 後、コンテキストが圧迫されてきたら /handoff を実行して
@@ -38,5 +49,11 @@
 
   home.file.".claude/skills/japanese-tech-writing/SKILL.md" = {
     source = ./claude-skills/japanese-tech-writing/SKILL.md;
+  };
+
+  # Hooks
+  home.file.".claude/hooks/safety-gate.sh" = {
+    source = ./claude-hooks/safety-gate.sh;
+    executable = true;
   };
 }

--- a/home/modules/development/claude-hooks/safety-gate.sh
+++ b/home/modules/development/claude-hooks/safety-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# safety-gate hook（PreToolUse）
+#
+# 機能:
+#   Claude Code がツールを実行する直前に呼ばれ、機密ファイルへのアクセスを
+#   検出したらブロックする（exit 2）。auto モード運用の安全網。
+#
+# 対象ツール:
+#   Read / Write / Edit / Bash / Grep（settings.json の matcher で指定）
+#
+# 判定:
+#   - ファイル系ツールは file_path / path を、Bash は command 文字列を検査する
+#   - 機密パターン（SSH 秘密鍵・credentials.json・.pem 等）に一致したらブロック
+#   - 公開鍵（.pub）は許可
+#   - .env / .envrc は direnv 運用のため意図的に許可（ブロックしない）
+#
+# 設定:
+#   home.file で ~/.claude/hooks/safety-gate.sh にデプロイし、
+#   ~/.claude/settings.json の hooks.PreToolUse に手動で登録する。
+#
+# 使用方法（テスト）:
+#   echo '{"tool_name":"Read","tool_input":{"file_path":"~/.ssh/id_rsa"}}' | ./safety-gate.sh
+
+set -u
+input=$(cat)
+
+# 検査対象の文字列（ツールごとに見る場所が違う）
+target=$(printf '%s' "$input" | /usr/bin/jq -r '
+  .tool_input.file_path // .tool_input.path // .tool_input.command // ""
+')
+
+[ -z "$target" ] && exit 0
+
+# 公開鍵は許可（秘密鍵パターンより先に判定）
+if printf '%s' "$target" | grep -qE '\.pub([[:space:]]|"|'"'"'|$)'; then
+  exit 0
+fi
+
+# 機密パターン
+patterns='credentials\.json|\.secrets|(^|/)id_(rsa|ed25519|ecdsa|dsa)|\.pem|\.p12|\.pfx|\.aws/credentials|(^|/)\.netrc|secring'
+
+if printf '%s' "$target" | grep -qE "$patterns"; then
+  echo "🛑 safety-gate: 機密ファイルへのアクセスをブロックしました" >&2
+  echo "   対象: $target" >&2
+  echo "   意図的な操作なら ~/.claude/hooks/safety-gate.sh のパターンを見直してください。" >&2
+  exit 2
+fi
+
+exit 0

--- a/home/modules/development/claude-hooks/safety-gate.sh
+++ b/home/modules/development/claude-hooks/safety-gate.sh
@@ -6,14 +6,15 @@
 #   Claude Code がツールを実行する直前に呼ばれ、機密ファイルへのアクセスを
 #   検出したらブロックする（exit 2）。auto モード運用の安全網。
 #
-# 対象ツール:
-#   Read / Write / Edit / Bash / Grep（settings.json の matcher で指定）
+# 対象ツールと判定:
+#   - Read / Write / Edit / NotebookEdit / Grep: file_path / path を検査し、
+#     機密パターンに一致したらブロック（公開鍵 .pub は許可）
+#   - Bash: command を検査するが、単に機密名を文字列として含むだけ
+#     （コミットメッセージ・PR 本文・ドキュメント等）は許可し、
+#     cat/cp/scp 等の読み出し・持ち出し系コマンドが機密ファイルを
+#     対象にした場合のみブロックする（誤爆防止）
 #
-# 判定:
-#   - ファイル系ツールは file_path / path を、Bash は command 文字列を検査する
-#   - 機密パターン（SSH 秘密鍵・credentials.json・.pem 等）に一致したらブロック
-#   - 公開鍵（.pub）は許可
-#   - .env / .envrc は direnv 運用のため意図的に許可（ブロックしない）
+#   .env / .envrc は direnv 運用のため意図的に許可（ブロックしない）。
 #
 # 設定:
 #   home.file で ~/.claude/hooks/safety-gate.sh にデプロイし、
@@ -25,26 +26,34 @@
 set -u
 input=$(cat)
 
-# 検査対象の文字列（ツールごとに見る場所が違う）
-target=$(printf '%s' "$input" | /usr/bin/jq -r '
-  .tool_input.file_path // .tool_input.path // .tool_input.command // ""
-')
+tool=$(printf '%s' "$input" | /usr/bin/jq -r '.tool_name // ""')
 
-[ -z "$target" ] && exit 0
+# 機密ファイル名のパターン
+secret='credentials\.json|\.secrets|id_(rsa|ed25519|ecdsa|dsa)|\.pem|\.p12|\.pfx|\.aws/credentials|\.netrc|secring'
 
-# 公開鍵は許可（秘密鍵パターンより先に判定）
-if printf '%s' "$target" | grep -qE '\.pub([[:space:]]|"|'"'"'|$)'; then
-  exit 0
-fi
-
-# 機密パターン
-patterns='credentials\.json|\.secrets|(^|/)id_(rsa|ed25519|ecdsa|dsa)|\.pem|\.p12|\.pfx|\.aws/credentials|(^|/)\.netrc|secring'
-
-if printf '%s' "$target" | grep -qE "$patterns"; then
+block() {
   echo "🛑 safety-gate: 機密ファイルへのアクセスをブロックしました" >&2
-  echo "   対象: $target" >&2
-  echo "   意図的な操作なら ~/.claude/hooks/safety-gate.sh のパターンを見直してください。" >&2
+  echo "   対象: $1" >&2
+  echo "   意図的な操作なら ~/.claude/hooks/safety-gate.sh を見直してください。" >&2
   exit 2
-fi
+}
+
+case "$tool" in
+  Read | Write | Edit | NotebookEdit | Grep)
+    target=$(printf '%s' "$input" | /usr/bin/jq -r '.tool_input.file_path // .tool_input.notebook_path // .tool_input.path // ""')
+    [ -z "$target" ] && exit 0
+    # 公開鍵は許可
+    printf '%s' "$target" | grep -qE '\.pub([[:space:]]|"|'"'"'|$)' && exit 0
+    printf '%s' "$target" | grep -qE "$secret" && block "$target"
+    ;;
+  Bash)
+    cmd=$(printf '%s' "$input" | /usr/bin/jq -r '.tool_input.command // ""')
+    [ -z "$cmd" ] && exit 0
+    # 読み出し・持ち出し系コマンドが機密ファイルを対象にした場合のみブロック。
+    # [^|;&]* で同一コマンドセグメント内に限定し、パイプ後の grep 等は対象外にする。
+    verbs='cat|less|more|head|tail|cp|scp|rsync|base64|xxd|strings|openssl|curl|nc'
+    printf '%s' "$cmd" | grep -qE "($verbs)[[:space:]]+[^|;&]*($secret)" && block "$cmd"
+    ;;
+esac
 
 exit 0


### PR DESCRIPTION
## 概要
機密ファイルへのアクセスをツール実行前にブロックする PreToolUse hook を追加する。
auto モード（defaultMode: auto + skipAutoPermissionPrompt）運用の安全網。closes #114

## 実装
- `home/modules/development/claude-hooks/safety-gate.sh` を home.file で `~/.claude/hooks/` にデプロイ
- ツールごとに判定を分岐:
  - Read / Write / Edit / NotebookEdit / Grep: file_path / path を検査し、機密パターンに一致したらブロック（公開鍵 .pub は許可）
  - Bash: `cat` / `cp` / `scp` 等の読み出し・持ち出し系コマンドが機密ファイルを対象にした場合のみブロック。単に機密名を文字列として含むだけ（コミットメッセージ・PR 本文・ドキュメント）は許可
- 機密パターン: SSH秘密鍵・credentials.json・.pem・.p12・.aws/credentials・.netrc 等
- `.env` / `.envrc` は direnv 運用のため意図的に許可

## 手動設定（nix 管理外）
`~/.claude/settings.json` の hooks.PreToolUse に登録済み（matcher: `Read|Write|Edit|Bash|Grep`）

## 動作確認
- 秘密鍵・credentials 系・Bash 経由の秘密鍵読み出し → ブロック（exit 2）
- 公開鍵・.env・.envrc・通常ファイル・機密名を含む文章のコマンド → 許可（exit 0）
- 実セッションで発火することを確認済み（当初 Bash で誤爆したため tool 別分岐に修正）
