### PR TITLE
feat: mpv を追加

### DIFF
--- a/systems/darwin/modules/homebrew.nix
+++ b/systems/darwin/modules/homebrew.nix
@@ -24,6 +24,7 @@
       "fastlane"
       "go"
       "ktlint"
+      "mpv"
     ];
     casks = [
       "discord"


### PR DESCRIPTION
## 概要
コマンドラインのメディアプレイヤー mpv を導入する。closes #124

## 変更内容
- `systems/darwin/modules/homebrew.nix` の brews に `mpv` を追加

## 方針
- macOS での動作安定性・導入速度を優先し Homebrew brews で管理（CLI ツールの管理方針に準拠）

## 動作確認
- rebuild 成功
- `mpv v0.41.0` の動作を確認（/opt/homebrew/bin/mpv）