### PR TITLE
feat: zsh のローカル設定読み込みと initContent 移行

### DIFF
--- a/home/modules/development/github.nix
+++ b/home/modules/development/github.nix
@@ -20,7 +20,7 @@
     pkgs.github-mcp-server
   ];
 
-  programs.zsh.initExtra = ''
+  programs.zsh.initContent = ''
     # github-mcp-server の認証トークンを gh CLI から動的取得
     if command -v gh &>/dev/null; then
       export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"

--- a/home/modules/shell/zsh.nix
+++ b/home/modules/shell/zsh.nix
@@ -6,6 +6,12 @@
   - lsd/eza: ls代替コマンド
   - bat: cat代替コマンド
   - direnv: ディレクトリ固有の環境変数管理（nix-direnv連携）
+
+  ローカル設定:
+  - ~/.zshrc.local があれば読み込む（実行時チェック）
+  - リポジトリに含めたくないマシン固有・PII を含む設定の置き場（追跡しない実ファイル）
+  - $HOME 直下に置く理由: dotDir(~/.config/zsh) は home-manager 管理下で
+    rebuild 時に手置きファイルが消えるため、管理外の $HOME に逃がす
 */
 { config, pkgs, ... }:
 {
@@ -19,6 +25,11 @@
     shellAliases = {
       rebuild = "sudo darwin-rebuild switch --flake ~/dotfiles#macOS";
     };
+    initContent = ''
+      # リポジトリ外のマシンローカル設定（存在すれば読み込む）
+      # $HOME 直下に置く（dotDir 内だと rebuild で消えるため）
+      [[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
+    '';
   };
 
   programs.lsd = {


### PR DESCRIPTION
## 概要
リポジトリに含めたくないマシンローカルな zsh 設定（PII を含むエイリアス・環境変数）を `~/.zshrc.local` から読み込めるようにする。closes #126

## 変更内容
- `home/modules/shell/zsh.nix`: initContent に `[[ -f ~/.zshrc.local ]] && source` を追加（実行時チェック）
- `home/modules/development/github.nix`: deprecated な `initExtra` を `initContent` に移行（警告解消）

## パス選定の理由
- dotDir(`~/.config/zsh`) は home-manager 管理下で、手置きファイルが rebuild 時に消える故障モードがあった
- そのため $HOME 直下（管理外）の `~/.zshrc.local` を使い、rebuild に巻き込まれないようにした

## 動作確認
- rebuild 成功・deprecation 警告なし
- 生成 zshrc に source 行を確認、使い捨てファイルで読み込みを確認
- `~/.zshrc.local` はリポジトリ外の手動作成ファイル（追跡しない）