### PR TITLE
feat: SwiftBar を追加

### DIFF
--- a/systems/darwin/modules/homebrew.nix
+++ b/systems/darwin/modules/homebrew.nix
@@ -33,6 +33,7 @@
       "obsidian"
       "sf-symbols"
       "slack"
+      "swiftbar"
       "visual-studio-code"
       "warp"
       "xquartz"


### PR DESCRIPTION
## 概要
メニューバーをカスタマイズできる SwiftBar を導入する。closes #129

## 変更内容
- `systems/darwin/modules/homebrew.nix` の casks に `swiftbar` を追加

## 方針
- メニューバー常駐の GUI アプリのため Homebrew cask で管理（GUIアプリは cask の方針に準拠）

## 動作確認
- rebuild 成功
- `/Applications/SwiftBar.app` の導入を確認