### PR TITLE
revert: SwiftBar を削除

### DIFF
--- a/systems/darwin/modules/homebrew.nix
+++ b/systems/darwin/modules/homebrew.nix
@@ -33,7 +33,6 @@
       "obsidian"
       "sf-symbols"
       "slack"
-      "swiftbar"
       "visual-studio-code"
       "warp"
       "xquartz"


### PR DESCRIPTION
## 概要
不要になったため SwiftBar を削除する（#130 の切り戻し）。

## 変更内容
- `systems/darwin/modules/homebrew.nix` の casks から `swiftbar` を削除（revert）

## 補足
- マージ後 rebuild すると cleanup（zap）でアプリもアンインストールされる